### PR TITLE
patch pod spec even if it's already been patched

### DIFF
--- a/pkg/handler/handler_test.go
+++ b/pkg/handler/handler_test.go
@@ -121,6 +121,48 @@ var rawPodWithVolume = []byte(`
 }
 `)
 
+var rawPodWithIAMTokenVolume = []byte(`
+{
+  "apiVersion": "v1",
+  "kind": "Pod",
+  "metadata": {
+	"name": "balajilovesoreos",
+	"uid": "be8695c4-4ad0-4038-8786-c508853aa255"
+  },
+  "spec": {
+	"containers": [
+	  {
+		"image": "amazonlinux",
+		"name": "balajilovesoreos",
+		"env": [
+			{
+				"name": "AWS_ROLE_ARN",
+				"value": "arn:aws:iam::111122223333:role/s3-reader"
+			},
+			{
+				"name": "AWS_WEB_IDENTITY_TOKEN_FILE",
+				"value": "/var/run/secrets/eks.amazonaws.com/serviceaccount/token"
+			}
+		],
+		"volumeMounts": [
+			{
+				"mountPath": "/var/run/secrets/eks.amazonaws.com/serviceaccount",
+				"name": "aws-iam-token",
+				"readOnly": true
+			}
+		]
+	  }
+	],
+	"serviceAccountName": "default",
+	"volumes": [
+	  {
+	    "name": "aws-iam-token"
+	  }
+	]
+  }
+}
+`)
+
 var rawWindowsBetaPodWithVolume = []byte(`
 {
   "apiVersion": "v1",
@@ -272,6 +314,8 @@ func getValidReview(pod []byte) *v1beta1.AdmissionReview {
 var validPatchIfNoVolumesPresent = []byte(`[{"op":"add","path":"/spec/volumes","value":[{"name":"aws-iam-token","projected":{"sources":[{"serviceAccountToken":{"audience":"sts.amazonaws.com","expirationSeconds":86400,"path":"token"}}]}}]},{"op":"add","path":"/spec/containers","value":[{"name":"balajilovesoreos","image":"amazonlinux","env":[{"name":"AWS_ROLE_ARN","value":"arn:aws:iam::111122223333:role/s3-reader"},{"name":"AWS_WEB_IDENTITY_TOKEN_FILE","value":"/var/run/secrets/eks.amazonaws.com/serviceaccount/token"}],"resources":{},"volumeMounts":[{"name":"aws-iam-token","readOnly":true,"mountPath":"/var/run/secrets/eks.amazonaws.com/serviceaccount"}]}]}]`)
 var validPatchIfVolumesPresent = []byte(`[{"op":"add","path":"/spec/volumes/0","value":{"name":"aws-iam-token","projected":{"sources":[{"serviceAccountToken":{"audience":"sts.amazonaws.com","expirationSeconds":86400,"path":"token"}}]}}},{"op":"add","path":"/spec/containers","value":[{"name":"balajilovesoreos","image":"amazonlinux","env":[{"name":"AWS_ROLE_ARN","value":"arn:aws:iam::111122223333:role/s3-reader"},{"name":"AWS_WEB_IDENTITY_TOKEN_FILE","value":"/var/run/secrets/eks.amazonaws.com/serviceaccount/token"}],"resources":{},"volumeMounts":[{"name":"aws-iam-token","readOnly":true,"mountPath":"/var/run/secrets/eks.amazonaws.com/serviceaccount"}]}]}]`)
 
+var validPatchIfIAMTokenVolumePresent = []byte(`[{"op":"add","path":"/spec/containers","value":[{"name":"balajilovesoreos","image":"amazonlinux","env":[{"name":"AWS_ROLE_ARN","value":"arn:aws:iam::111122223333:role/s3-reader"},{"name":"AWS_WEB_IDENTITY_TOKEN_FILE","value":"/var/run/secrets/eks.amazonaws.com/serviceaccount/token"},{"name":"AWS_DEFAULT_REGION","value":"seattle"},{"name":"AWS_REGION","value":"seattle"}],"resources":{},"volumeMounts":[{"name":"aws-iam-token","readOnly":true,"mountPath":"/var/run/secrets/eks.amazonaws.com/serviceaccount"}]}]}]`)
+
 var validPatchIfWindowsNoVolumesPresent = []byte(`[{"op":"add","path":"/spec/volumes","value":[{"name":"aws-iam-token","projected":{"sources":[{"serviceAccountToken":{"audience":"sts.amazonaws.com","expirationSeconds":86400,"path":"token"}}]}}]},{"op":"add","path":"/spec/containers","value":[{"name":"balajilovesoreos","image":"amazonlinux","env":[{"name":"AWS_ROLE_ARN","value":"arn:aws:iam::111122223333:role/s3-reader"},{"name":"AWS_WEB_IDENTITY_TOKEN_FILE","value":"C:\\var\\run\\secrets\\eks.amazonaws.com\\serviceaccount\\token"}],"resources":{},"volumeMounts":[{"name":"aws-iam-token","readOnly":true,"mountPath":"/var/run/secrets/eks.amazonaws.com/serviceaccount"}]}]}]`)
 var validPatchIfWindowsVolumesPresent = []byte(`[{"op":"add","path":"/spec/volumes/0","value":{"name":"aws-iam-token","projected":{"sources":[{"serviceAccountToken":{"audience":"sts.amazonaws.com","expirationSeconds":86400,"path":"token"}}]}}},{"op":"add","path":"/spec/containers","value":[{"name":"balajilovesoreos","image":"amazonlinux","env":[{"name":"AWS_ROLE_ARN","value":"arn:aws:iam::111122223333:role/s3-reader"},{"name":"AWS_WEB_IDENTITY_TOKEN_FILE","value":"C:\\var\\run\\secrets\\eks.amazonaws.com\\serviceaccount\\token"}],"resources":{},"volumeMounts":[{"name":"aws-iam-token","readOnly":true,"mountPath":"/var/run/secrets/eks.amazonaws.com/serviceaccount"}]}]}]`)
 
@@ -292,6 +336,13 @@ var validResponseIfVolumesPresent = &v1beta1.AdmissionResponse{
 	UID:       "",
 	Allowed:   true,
 	Patch:     validPatchIfVolumesPresent,
+	PatchType: &jsonPatchType,
+}
+
+var validResponseIfIAMTokenVolumePresent = &v1beta1.AdmissionResponse{
+	UID:       "",
+	Allowed:   true,
+	Patch:     validPatchIfIAMTokenVolumePresent,
 	PatchType: &jsonPatchType,
 }
 
@@ -439,6 +490,12 @@ func TestEnvUpdate(t *testing.T) {
 			NewModifier(WithServiceAccountCache(cache.NewFakeServiceAccountCache(testServiceAccount)), WithRegion("seattle")),
 			getValidReview(rawPodWithAWSDefaultRegion),
 			validResponseIfDefaultRegionPresent,
+		},
+		{
+			"ValidRequestSuccessWithIAMTokenVolumePresent",
+			NewModifier(WithServiceAccountCache(cache.NewFakeServiceAccountCache(testServiceAccount)), WithRegion("seattle")),
+			getValidReview(rawPodWithIAMTokenVolume),
+			validResponseIfIAMTokenVolumePresent,
 		},
 	}
 


### PR DESCRIPTION
before, the updatePodSpec function would return immediately if it detected that the
aws-iam-token volume was already present.

This patch modifies the behavior so that the function continues to
inject environment variables and volume mounts as needed.

Specifically, the behavior of injecting env vars, volume mounts, and
volumes is now:

1. For each env var in "AWS_ROLE_ARN, AWS_WEB_IDENTITY_TOKEN_FILE,
AWS_REGION, AWS_DEFAULT_REGION", inject if not already present in
container spec

2. Inject volume mount if not already present in container spec

3. Inject volume if not already present in pod spec

Upstream Issue: https://github.com/aws/amazon-eks-pod-identity-webhook/issues/61
